### PR TITLE
Cleanly return early when not in git repo

### DIFF
--- a/git-tree.py
+++ b/git-tree.py
@@ -3,7 +3,9 @@
 
 import os
 import subprocess
+
 from collections import defaultdict
+from sys import exit
 
 
 class ColorFG:
@@ -158,6 +160,11 @@ def print_table(print_outs, branches):
 
 
 def main():
+    try:
+        subprocess.check_output(["git", "rev-parse", "--is-inside-work-tree"])
+    except:
+        exit(1)
+
     branches, tree = parse_branches()
     print_outs = []
     collect_depth_first_print_order(tree, "root", "", print_outs)


### PR DESCRIPTION
Before change:
```
 󰝰 ~/third-party .......................................................................................................................................................  09:18
❯ git t
fatal: not a git repository (or any of the parent directories): .git
Traceback (most recent call last):
  File "/Users/ttd/third-party/git-branch-tree-fork/git-tree.py", line 168, in <module>
    main()
    ~~~~^^
  File "/Users/ttd/third-party/git-branch-tree-fork/git-tree.py", line 161, in main
    branches, tree = parse_branches()
                     ~~~~~~~~~~~~~~^^
  File "/Users/ttd/third-party/git-branch-tree-fork/git-tree.py", line 71, in parse_branches
    git_br_output = subprocess.check_output(["git", "branch", "-vv"])
  File "/opt/homebrew/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/subprocess.py", line 472, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
               **kwargs).stdout
               ^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/subprocess.py", line 577, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['git', 'branch', '-vv']' returned non-zero exit status 128.
```

After:
```
 󰝰 ~/third-party .......................................................................................................................................................  09:18
❯ git t
fatal: not a git repository (or any of the parent directories): .git
```