### PR TITLE
Provide visual indication of an assumed upstream branch in tree

### DIFF
--- a/git-tree.py
+++ b/git-tree.py
@@ -32,7 +32,7 @@ def assume_main_is_upstream(upstream_branch):
 
 
 class GitBranch:
-    def __init__(self, branch_printout, github_pr_info, main_branch_name):
+    def __init__(self, branch_printout, main_branch_name, github_pr_info):
         branch_details = branch_printout.decode("ASCII")
         # Parse details of form "<*> <name> <commit> ([<upstream_info>]) <commit_details>"
         # Active branch in current worktree starts with "* ".


### PR DESCRIPTION
For branches with no upstream that are assumed to be downstream of the main branch, show that with a dashed yellow line in the tree printout. (For example `assume_master_upstream` branch in the image below.

![image](https://github.com/user-attachments/assets/359624ef-ee98-4ca2-a3d5-3aee5f2abccf)
