### PR TITLE
Add --concise flag that turns off gh PR query and printout

### DIFF
--- a/git-tree.py
+++ b/git-tree.py
@@ -212,7 +212,7 @@ def calculate_branch_column_width(print_outs, branches):
     return max(branch_column_widths) + 2
 
 
-def print_table(print_outs, branches, consise=False, highlight_branch=""):
+def print_table(print_outs, branches, concise=False, highlight_branch=""):
     """
     Take the branch-structure print_outs,
     Derive additional column information according to the branches[],


### PR DESCRIPTION

```
❯ git tree --concise
Branch                                  Deltas  Commit
================================================================
 master                                        32a8784
  ├──assume_master_upstream                    0174303
  ├──assumed_upstream_special_display  +3:-2   62c4f60
  ├──gh_integration                    +6:-1   4372db8
  ├──highlight_flag                    +1:-0   4f4d0d6
  │  └──concise_printout               +1:-0   492476a
  └──hyperlinks                        +4:-0   d4d50c9
```

vs

```
❯ git tree
Branch                                  Deltas  Commit   Status  PR Link
==================================================================================
 master                                        32a8784
  ├──assume_master_upstream                    0174303  MERGED  https://github.com/charlestytler/git-branch-tree/pull/14
  ├──assumed_upstream_special_display  +3:-2   62c4f60  OPEN    https://github.com/charlestytler/git-branch-tree/pull/19
  ├──gh_integration                    +6:-1   4372db8  MERGED  https://github.com/charlestytler/git-branch-tree/pull/11
  ├──highlight_flag                    +1:-0   4f4d0d6  OPEN    https://github.com/charlestytler/git-branch-tree/pull/15
  │  └──concise_printout               +1:-0   492476a
  └──hyperlinks                        +4:-0   d4d50c9  OPEN    https://github.com/charlestytler/git-branch-tree/pull/18

```