### PR TITLE
Change prefix character for assumed main upstream

### DIFF
--- a/git-tree.py
+++ b/git-tree.py
@@ -280,7 +280,7 @@ def print_table(print_outs, branches, concise=False, highlight_branch=""):
         column_width_count = len(tree_prefix) + len(branch_name)
         if assume_main_is_upstream(branch.upstream_branch):
             tree_prefix = (
-                ColorFG.YELLOW + tree_prefix.replace("─", "-") + ColorFG.DEFAULT
+                ColorFG.YELLOW + tree_prefix.replace("─", "╶") + ColorFG.DEFAULT
             )
         first_column = tree_prefix + branch_name
         if branch.active_on_other_worktree:


### PR DESCRIPTION
I used a [box drawing](https://en.wikipedia.org/wiki/List_of_Unicode_characters#Box_Drawing) character to avoid my terminal including the hyphen when I select the entire branch name via double-click. It also lines up better with the vertical character. 

Before change:
<img width="534" alt="Screenshot 2025-02-28 at 9 01 39 PM" src="https://github.com/user-attachments/assets/6e95e452-e1b5-4ea7-b289-8134e89e246b" />

After change:
<img width="957" alt="Screenshot 2025-02-28 at 9 00 34 PM" src="https://github.com/user-attachments/assets/54faa1a2-47f7-4281-9323-098c9be0a9d7" />
